### PR TITLE
118 putting the create item page to the profile page

### DIFF
--- a/front-end/src/components/AppController/AppController.js
+++ b/front-end/src/components/AppController/AppController.js
@@ -3,7 +3,7 @@ import { homeComponent } from "../homePage/homePage.js";
 import { profilePage } from "../mainProfilePage/mainProfilePage.js";
 import { ProfileLoginPage } from "../ProfileLoginPage/ProfileLoginPage.js";
 import { Registration } from "../registrationPage/registrationPage.js";
-import {CreateItemPage} from "../itemPage/createItemPage.js";
+// import {CreateItemPage} from "../itemPage/createItemPage.js";
 import { EventHub } from "../../eventhub/EventHub.js";
 
 export class AppController {
@@ -14,7 +14,7 @@ export class AppController {
     #profilePage = null;
     #loginPage = null;
     #registerPage = null;
-    #createItemPage = null;
+    // #createItemPage = null;
     #hub = null;
 
     constructor(){
@@ -24,7 +24,7 @@ export class AppController {
         this.#profilePage = new profilePage();
         this.#loginPage = new ProfileLoginPage();
         this.#registerPage = new Registration();
-        this.#createItemPage = new CreateItemPage();
+        // this.#createItemPage = new CreateItemPage();
     }
 
     render() {
@@ -37,7 +37,7 @@ export class AppController {
         this.#profilePage.render();
         this.#loginPage.render();
         this.#registerPage.render();
-        this.#createItemPage.render();
+        // this.#createItemPage.render();
 
         this.#renderCurrentView();
 
@@ -61,7 +61,7 @@ export class AppController {
         const exploreBtn = document.getElementById('exploreBtn');
         const profileBtn = document.getElementById('profileBtn');
         const loginBtn = document.getElementById('loginBtn');
-        const createItemBtn = document.getElementById('itemBtn');
+        // const createItemBtn = document.getElementById('itemBtn');
 
         homeBtn.addEventListener('click', () => {
             this.#toggleView('home');
@@ -78,9 +78,9 @@ export class AppController {
         loginBtn.addEventListener('click', () => {
             this.#toggleView('login');
         });
-        createItemBtn.addEventListener('click', () => {
-            this.#toggleView('createItem');
-        });
+        // createItemBtn.addEventListener('click', () => {
+        //     this.#toggleView('createItem');
+        // });
 
         this.#hub.subscribe('SwitchToHomePage', () => {
             this.#currentView = 'home';
@@ -106,10 +106,10 @@ export class AppController {
             this.#currentView = 'register';
             this.#renderCurrentView();
         });
-        this.#hub.subscribe('SwitchToCreateItemPage', () => {
-            this.#currentView = 'createItem';
-            this.#renderCurrentView();
-        });
+        // this.#hub.subscribe('SwitchToCreateItemPage', () => {
+        //     this.#currentView = 'createItem';
+        //     this.#renderCurrentView();
+        // });
     }
 
     #toggleView(view) {
@@ -129,10 +129,10 @@ export class AppController {
             this.#currentView = view;
             this.#hub.publish('SwitchToRegisterPage', null);
         }
-        else if(view === 'createItem'){
-            this.#currentView = view;
-            this.#hub.publish('SwitchToCreateItemPage', null);
-        }   
+        // else if(view === 'createItem'){
+        //     this.#currentView = view;
+        //     this.#hub.publish('SwitchToCreateItemPage', null);
+        // }   
     }
 
     #renderCurrentView(){
@@ -150,8 +150,8 @@ export class AppController {
         }else if(this.#currentView === 'register'){
             viewContainer.appendChild(this.#registerPage.render());
         }
-        else if(this.#currentView === 'createItem'){
-            viewContainer.appendChild(this.#createItemPage.render());
-        }
+        // else if(this.#currentView === 'createItem'){
+        //     viewContainer.appendChild(this.#createItemPage.render());
+        // }
     }
 }

--- a/front-end/src/components/ProfileController/ProfileController.js
+++ b/front-end/src/components/ProfileController/ProfileController.js
@@ -4,6 +4,7 @@ import { NotificationList } from "../NotificationList/NotificationList.js"
 import { ViewProfile } from "../ViewProfile/ViewProfile.js";
 import { conversationList } from "../conversation/conversation.js";
 import { Achievement } from "../Achievement/Achievement.js";
+import {CreateItemPage} from "../itemPage/createItemPage.js";
 //TODO: Import other screens here
 import { EditProfilePage } from "../editProfilePage/editProfilePage.js";
 
@@ -14,6 +15,7 @@ export class ProfileContoller extends BaseComponent {
   #viewProfile = null;
   #conversationList = null;
   #achievements = null;
+  #createitems = null;
   //TODO: Add other screens here
   #hub = null;
   #editorPage = null;
@@ -27,6 +29,7 @@ export class ProfileContoller extends BaseComponent {
     this.#achievements = new Achievement();
     //TODO: Instantiate other screens here
     this.#editorPage = new EditProfilePage();
+    this.#createitems = new CreateItemPage();
     this.loadCSS("ProfileController");
   }
 
@@ -42,6 +45,7 @@ export class ProfileContoller extends BaseComponent {
     //TODO: Render other screens here
     this.#conversationList.render();
     this.#editorPage.render();
+    this.#createitems.render();
 
     this.#renderCurrentView();
 
@@ -60,6 +64,7 @@ export class ProfileContoller extends BaseComponent {
     this.#container.innerHTML = `
       <div id="sidebar">
         <button id="viewProfileBtn">View Profile</button>
+        <button id="createItemBtn">Create Item</button>
         <button id="viewNotifBtn">Notifications</button>
         <button id="viewConvoBtn">Conversations</button>
         <button id="viewAchievementsBtn">Achievements</button>
@@ -72,6 +77,7 @@ export class ProfileContoller extends BaseComponent {
   // Attach needed event listeners
   #attachEventListeners() {
     const viewProfileBtn = this.#container.querySelector('#viewProfileBtn');
+    const createItemBtn = this.#container.querySelector('#createItemBtn');
     const viewNotifBtn = this.#container.querySelector('#viewNotifBtn');
     const viewConvoBtn = this.#container.querySelector('#viewConvoBtn');
     const viewAchievementsBtn = this.#container.querySelector('#viewAchievementsBtn');
@@ -81,7 +87,10 @@ export class ProfileContoller extends BaseComponent {
     viewProfileBtn.addEventListener('click', () => {
       this.#toggleView('profile');
     });
-
+    // Event listener for switching to create item view
+    createItemBtn.addEventListener('click', () => {
+      this.#toggleView('createItem');
+    });
     // Event listener for switching to notification view
     viewNotifBtn.addEventListener('click', () => {
       this.#toggleView('notif');
@@ -106,6 +115,11 @@ export class ProfileContoller extends BaseComponent {
 
 
     // Subscribe to event hub events to manage switching
+    this.#hub.subscribe('SwitchProfileToCreateItem', () => {  
+      this.#currentView = 'createItem';
+      this.#renderCurrentView();
+    });
+
     this.#hub.subscribe('SwitchProfileToNotif', () => {
       this.#currentView = 'notif';
       this.#renderCurrentView();
@@ -120,6 +134,7 @@ export class ProfileContoller extends BaseComponent {
       this.#currentView = 'convo';
       this.#renderCurrentView();
     })
+    
 
     this.#hub.subscribe('SwitchProfileToAchievements', () => {
       this.#currentView = 'achievements';
@@ -134,6 +149,10 @@ export class ProfileContoller extends BaseComponent {
 
   // Toggle view based on button pressed
   #toggleView(view) {
+    if(view === 'createItem'){
+      this.#currentView = view;
+      this.#hub.publish('SwitchProfileToCreateItem', null);
+    }
     if(view === 'notif'){
       this.#currentView = view;
       this.#hub.publish('SwitchProfileToNotif', null);
@@ -164,7 +183,9 @@ export class ProfileContoller extends BaseComponent {
   #renderCurrentView() {
     const viewContainer = this.#container.querySelector('#viewContainer');
     viewContainer.innerHTML = '';
-
+    if (this.#currentView === 'createItem'){
+      viewContainer.appendChild(this.#createitems.render());
+    }
     if (this.#currentView === 'notif'){
       viewContainer.appendChild(this.#notificationList.render());
     }

--- a/front-end/src/index.html
+++ b/front-end/src/index.html
@@ -21,7 +21,7 @@
 
               <li><a href="#" id="exploreBtn">Explore</a></li> <!-- Create the necessary page to link on here-->
               <li><a href="#" id="profileBtn">Profile</a></li> <!-- Create the necessary page to link on here-->
-              <li><a href="#" id="itemBtn">Create Item</a></li>
+              <!-- <li><a href="#" id="itemBtn">Create Item</a></li> -->
 
 
               <li><a href="#" id="loginBtn">Login</a></li>


### PR DESCRIPTION
Move "Create Item" Page to Profile Page

This PR integrates the "Create Item" functionality directly into the Profile page to streamline the user experience and centralize content management.

Key Changes:

Moved the "Create Item" component to the Profile page.
Updated routing and navigation logic to reflect the new structure.
Refactored styles and layout to ensure seamless integration with the Profile page design.
Verified responsiveness and usability across devices.
Purpose: To improve usability by consolidating item creation within the user’s profile, making it easier to access and manage.